### PR TITLE
Fix for IOS import paths

### DIFF
--- a/src/ios/SocialMessage.h
+++ b/src/ios/SocialMessage.h
@@ -3,8 +3,8 @@
 //  Copyright (c) 2013 Lee Crossley - http://ilee.co.uk
 //
 
-#import "Cordova/CDV.h"
-#import "Foundation/Foundation.h"
+#import <Cordova/CDVPlugin.h>
+#import <Foundation/Foundation.h>
 
 @interface SocialMessage : CDVPlugin
 

--- a/src/ios/SocialMessage.m
+++ b/src/ios/SocialMessage.m
@@ -3,7 +3,6 @@
 //  Copyright (c) 2013 Lee Crossley - http://ilee.co.uk
 //
 
-#import "Cordova/CDV.h"
 #import "SocialMessage.h"
 
 @implementation SocialMessage


### PR DESCRIPTION
I'm using an online build service (appgyver) for phonegap/cordova and this was causing the ios builds to fail, it would be nice if someone could test it in a real offline build environment too...
