### PR TITLE
Added success/cancel option for IOS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ var message = {
 window.socialmessage.send(message);
 ```
 
+### Add success/cancelled alerts after share (IOS Only)
+
+To turn on success/cancel alerts to your sharing after the share is done:
+
+```
+var message = {
+    text: "Image test",
+    showAlert: true
+};
+window.socialmessage.send(message);
+```
+
 ## Platforms
 
 Currently supporting iOS and Android - check back soon for Windows Phone 8 support.

--- a/src/ios/SocialMessage.m
+++ b/src/ios/SocialMessage.m
@@ -14,6 +14,7 @@
     NSString *url = [args objectForKey:@"url"];
     NSString *image = [args objectForKey:@"image"];
     NSString *subject = [args objectForKey:@"subject"];
+    NSString *showAlert = [args objectForKey:@"showAlert"];
     NSArray *activityTypes = [[args objectForKey:@"activityTypes"] componentsSeparatedByString:@","];
 
     NSMutableArray *items = [NSMutableArray new];
@@ -99,6 +100,28 @@
     }
 
     activity.excludedActivityTypes = exclusions;
+    
+    if (showAlert)
+    {
+        BOOL doAlert = [showAlert boolValue];
+        if (doAlert) {
+            [activity setCompletionHandler:^(NSString *act, BOOL done)
+             {
+                NSString *serviceMsg = @"Share was cancelled";
+                 
+                if(done)
+                {
+                    serviceMsg = @"Share completed successfully.";
+                    if ( [act isEqualToString:UIActivityTypeMail] )           serviceMsg = @"Mail sent successfully";
+                    if ( [act isEqualToString:UIActivityTypePostToTwitter] )  serviceMsg = @"Post was successful";
+                    if ( [act isEqualToString:UIActivityTypePostToFacebook] ) serviceMsg = @"Post was successful";
+                }
+                 
+                 UIAlertView *Alert = [[UIAlertView alloc] initWithTitle:serviceMsg message:@"" delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil];
+                 [Alert show];
+             }];
+        }
+    }
 
     [self.viewController presentViewController:activity animated:YES completion:Nil];
 }


### PR DESCRIPTION
I needed this for a client request I got. Made it optional. Could be extended to allowing customization of the messages and such, but felt this was a good start. If you like it, please feel free to pull it in.