### PR TITLE
Facebook Intent with URL

### DIFF
--- a/src/android/SocialMessage.java
+++ b/src/android/SocialMessage.java
@@ -5,6 +5,7 @@
 
 package uk.co.ilee.socialmessage;
 
+import java.util.*;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -18,33 +19,47 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONException;
 import android.content.Intent;
+import android.content.Context;
+import android.content.DialogInterface;
 import android.net.Uri;
+import android.text.TextUtils;
 import android.os.Environment;
-
+import android.os.Parcelable;
+import android.app.AlertDialog;
+import android.content.pm.PackageInfo;
+import android.content.pm.ResolveInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import org.apache.cordova.LOG;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
 
 @SuppressLint("DefaultLocale")
 public class SocialMessage extends CordovaPlugin {
 
+	Context ctx;
 	@Override
 	public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+		ctx = this.cordova.getActivity().getApplicationContext();
 		JSONObject json = args.getJSONObject(0);
 		String text = getJSONProperty(json, "text");
 		String subject = getJSONProperty(json, "subject");
 		String url = getJSONProperty(json, "url");
+		String shortUrl = getJSONProperty(json, "short_url");
 		String image = getJSONProperty(json, "image");
-		if (url != null && url.length() > 0) {
-			if (text == null) {
-				text = url;
-			} else {
-				text = text + " " + url;
-			}
-		}
+		String chooserTitle = getJSONProperty(json, "chooser_title");
 		try {
-			doSendIntent(text, subject, image);
+			String returnString = doSendIntent(text, subject, image, url, shortUrl, chooserTitle);
+
+			PluginResult result = new PluginResult(PluginResult.Status.OK, returnString);
+			result.setKeepCallback(true);
+		callbackContext.sendPluginResult(result);
 		} catch (IOException e) {
 			e.printStackTrace();
+			PluginResult result = new PluginResult(PluginResult.Status.OK, "ERROR");
+			result.setKeepCallback(true);
 		}
 		return true;
 	}
@@ -56,35 +71,72 @@ public class SocialMessage extends CordovaPlugin {
 		return null;
 	}
 
-	private void doSendIntent(String text, String subject, String image) throws IOException {
-		final Intent sendIntent = new Intent(android.content.Intent.ACTION_SEND);
-		if (text != null && text.length() > 0) {
-			sendIntent.putExtra(android.content.Intent.EXTRA_TEXT, text);
+	private String doSendIntent(String text, String subject, String image, String url, String shortUrl, String chooserTitle) throws IOException {
+        List<Intent> targetedShareIntents = new ArrayList<Intent>();
+        Intent intent = new Intent(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        String returnString="";
+
+		Uri picturePath = null;
+
+		if (chooserTitle == null)
+		{
+			chooserTitle = "Share...";
 		}
-		if (subject != null && subject.length() > 0) {
-			sendIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, subject);
-		}
+
 		if (image != null && image.length() > 0) {
-			sendIntent.setType("image/*");
-			final URL url = new URL(image);
+			final URL imageUrl = new URL(image);
 			String storageDir = Environment.getExternalStorageDirectory().getPath();
 			final String path = storageDir + "/" + image.substring(image.lastIndexOf("/") + 1, image.length());
 			cordova.getThreadPool().execute(new Runnable() {
 				@Override
 				public void run() {
 					try {
-						saveImage(url, path);
-						sendIntent.putExtra(Intent.EXTRA_STREAM, Uri.fromFile(new File(path)));
-						cordova.getActivity().startActivityForResult(sendIntent, 0);
+						saveImage(imageUrl, path);
 					} catch (Exception e) {
 						e.printStackTrace();
 					}
 				}
 			});
-		} else {
-			sendIntent.setType("text/plain");
-			cordova.startActivityForResult(this, sendIntent, 0);
+
+			picturePath =  Uri.fromFile(new File(path));
 		}
+
+        List<ResolveInfo> matches = ctx.getPackageManager().queryIntentActivities(intent, 0);
+        for (ResolveInfo info : matches) {
+			if (info.activityInfo.packageName != null && info.activityInfo.packageName.length() > 0)
+			{
+				final Intent targetedShareIntent = new Intent(Intent.ACTION_SEND);
+				targetedShareIntent.setClassName(info.activityInfo.packageName,info.activityInfo.name);
+				if (info.activityInfo.packageName.toLowerCase().startsWith("com.facebook") && url != null) {
+					targetedShareIntent.putExtra(Intent.EXTRA_TEXT, url);
+					targetedShareIntent.setType("text/plain");
+				}
+				else
+				{
+					if (subject != null && subject.length() > 0) {
+						targetedShareIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, subject);
+					}
+					if (text != null && text.length() > 0) {
+						targetedShareIntent.putExtra(android.content.Intent.EXTRA_TEXT, subject+ " | " + text + "\n" + shortUrl);
+					}
+					if (picturePath != null) {
+						targetedShareIntent.setType("image/*");
+						targetedShareIntent.putExtra(Intent.EXTRA_STREAM, picturePath);
+					}
+					else {
+						targetedShareIntent.setType("text/plain");
+					}
+				}
+				targetedShareIntents.add(targetedShareIntent);
+            }
+        }
+
+		Intent chooserIntent = Intent.createChooser(targetedShareIntents.remove(0), chooserTitle);
+		chooserIntent.putExtra(Intent.EXTRA_INITIAL_INTENTS, targetedShareIntents.toArray(new Parcelable[]{}));
+        cordova.getActivity().startActivityForResult(chooserIntent, 0);
+
+		return returnString;
 	}
 	
 	public static void saveImage(URL url, String outputPath) throws IOException {

--- a/www/socialmessage.js
+++ b/www/socialmessage.js
@@ -1,3 +1,4 @@
+
 var exec = require("cordova/exec");
 
 var SocialMessage = function () {

--- a/www/socialmessage.js
+++ b/www/socialmessage.js
@@ -1,4 +1,3 @@
-
 var exec = require("cordova/exec");
 
 var SocialMessage = function () {


### PR DESCRIPTION
If you send an URL and share to facebook, create a specific Intent with only url content.
It allow to share link+ picture content as Facebook will use opengraph to get page content.

As Intent use now an Intent.chooser to get the list of apps user can share to, I added a new parameter to the message: choose_title.

If it's empty, chooser title will be "Share..."
